### PR TITLE
Unmount proc when completing execve

### DIFF
--- a/userchroot.c
+++ b/userchroot.c
@@ -322,7 +322,8 @@ static int proc_guard(void *v) {
     fprintf(stderr, "Failed to clone. Error: %s\n", strerror(errno));
   }
   else {
-    int child_status = 0;
+    // init to -1 in case waitpid fails and leaves it untouched.
+    int child_status = -1;
     int p = 0;
     while (p = waitpid(child_pid, &child_status, 0)) {
       if (p == child_pid || p == -1) {
@@ -605,7 +606,7 @@ int main(int argc, char* argv[], char* envp[]) {
       return child_pid;
     }
     else {
-      int child_status = 0;
+      int child_status = -1;
       int p = 0;
       while (p = waitpid(child_pid, &child_status, 0)) {
         if (p == child_pid || p == -1) {

--- a/userchroot.c
+++ b/userchroot.c
@@ -330,7 +330,11 @@ static int proc_guard(void *v) {
         int child_status = 0;
         waitpid(child_pid, &child_status, 0);
 
-        umount("proc");
+        int umount_rc = umount("/proc");
+
+        if (umount_rc) {
+          fprintf(stderr, "Failed to umount. Error: %s\n", strerror(errno));
+        }
 
         return child_status;
     }


### PR DESCRIPTION
Add another level of process indirection so that when the child exists from running execve we tidy up after it and umount the proc we mounted earlier.

Fixes https://github.com/bloomberg/userchroot/issues/2.