### PR TITLE
Add support for /dev/poll on Solaris

### DIFF
--- a/fundamental_devices.c
+++ b/fundamental_devices.c
@@ -163,6 +163,12 @@ int create_fundamental_devices(const char* chroot_path) {
     }
     free(fullpath);
 #endif
+
+  // add mount for /dev/poll on Solaris
+#if defined(sun) || defined(__sun)
+  create_fundamental_device(chroot_path,"/dev/poll");
+#endif
+
   umask(original_mask);
   return 0;
 }
@@ -172,6 +178,7 @@ int unlink_fundamental_devices(const char* chroot_path) {
   unlink_fundamental_device(chroot_path,"/dev/zero");
   unlink_fundamental_device(chroot_path,"/dev/random");
   unlink_fundamental_device(chroot_path,"/dev/urandom");
+
   // unmount /dev/shm for linux only
 #ifdef __linux__
     char *fullpath = (char *)
@@ -191,6 +198,12 @@ int unlink_fundamental_devices(const char* chroot_path) {
     }
     free(fullpath);
 #endif
+
+  // unmount /dev/poll on Solaris
+#if defined(sun) || defined(__sun)
+  unlink_fundamental_device(chroot_path,"/dev/poll");
+#endif
+
   return 0;
 }
 


### PR DESCRIPTION
Add support for the `/dev/poll` kernel driver on Solaris, this is a replacement for `select` or `poll` specific to Solaris. This is safe to use in a chroot, every process that opens `/dev/poll` gets a separate connection to the poll driver and is isolated from one another by the kernel. See http://docs.oracle.com/cd/E19253-01/816-5177/6mbbc4g9n/index.html .