### PR TITLE
Improve isolation and robustness on Linux

### DIFF
--- a/fundamental_devices.c
+++ b/fundamental_devices.c
@@ -12,10 +12,6 @@
 #include <sys/mount.h>
 #endif
 
-#ifdef __linux__
-#include <sys/mount.h>
-#endif
-
 #include "userchroot.h"
 #include "fundamental_devices.h"
 
@@ -117,53 +113,6 @@ int create_fundamental_devices(const char* chroot_path) {
   create_fundamental_device(chroot_path,"/dev/random");
   create_fundamental_device(chroot_path,"/dev/urandom");
 
-  // add a mount for /dev/shm for linux only
-#ifdef __linux__
-    char *fullpath = (char *)
-        malloc(strlen(chroot_path) + strlen("/dev/shm") + 1);
-    sprintf(fullpath, "%s/dev/shm", chroot_path);
-
-    struct stat statbuf;
-    mode_t perms = (0777 | S_ISVTX);
-
-    // clean up from a previous run and set up for this one
-    umount2(fullpath, MNT_FORCE);
-    rmdir(fullpath);
-    mkdir(fullpath, perms);
-    if (chown(fullpath, 0, 0) < 0)
-    {
-        fprintf(stderr, "Could not chown %s to root.  Aborting.\n", fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    if (chmod(fullpath, perms) < 0)
-    {
-        fprintf(stderr, "Could not chmod %s to 777+sticky.  Aborting.\n",
-            fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    if (stat(fullpath, &statbuf) < 0)
-    {
-        fprintf(stderr, "Could not stat %s.  Aborting.\n", fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    if (!S_ISDIR(statbuf.st_mode))
-    {
-        fprintf(stderr, "%s not a directory.  Aborting.\n", fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    if ((statbuf.st_mode & perms) != perms)
-    {
-        fprintf(stderr, "Wrong perms on %s.  Aborting.\n", fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    if (mount("tmpfs", fullpath, "tmpfs", MS_MGC_VAL, "size=128m") < 0)
-    {
-        fprintf(stderr, "Could not mount %s.  Aborting.\n", fullpath);
-        exit(ERR_EXIT_CODE);
-    }
-    free(fullpath);
-#endif
-
   // add mount for /dev/poll on Solaris
 #if defined(sun) || defined(__sun)
   create_fundamental_device(chroot_path,"/dev/poll");
@@ -178,26 +127,6 @@ int unlink_fundamental_devices(const char* chroot_path) {
   unlink_fundamental_device(chroot_path,"/dev/zero");
   unlink_fundamental_device(chroot_path,"/dev/random");
   unlink_fundamental_device(chroot_path,"/dev/urandom");
-
-  // unmount /dev/shm for linux only
-#ifdef __linux__
-    char *fullpath = (char *)
-        malloc(strlen(chroot_path) + strlen("/dev/shm") + 1);
-    sprintf(fullpath, "%s/dev/shm", chroot_path);
-    if (umount2(fullpath, MNT_FORCE) < 0)
-    {
-        fprintf(stderr, "Could not unmount %s (%s).  Aborting.\n",
-            fullpath, strerror(errno));
-        exit(ERR_EXIT_CODE);
-    }
-    if (rmdir(fullpath) < 0)
-    {
-        fprintf(stderr, "Could not rmdir %s (%s).  Aborting.\n",
-            fullpath, strerror(errno));
-        exit(ERR_EXIT_CODE);
-    }
-    free(fullpath);
-#endif
 
   // unmount /dev/poll on Solaris
 #if defined(sun) || defined(__sun)

--- a/userchroot.c
+++ b/userchroot.c
@@ -277,8 +277,7 @@ void epilogue(struct epilogue_data* d) {
   exit(ERR_EXIT_CODE);
 }
 
-#if defined (__linux__) && defined (MOUNT_PROC)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+#if defined USERCHROOT_USE_LINUX_CLONE
 
 static char child_stack[1048576];
 
@@ -303,6 +302,7 @@ static int child_fn(void* v) {
     return rc;
   }
 
+#if defined (MOUNT_PROC)
   // Since we're in the chroot, we don't need to unmount the current
   // proc, simply because there isn't any current proc mounted.
   //
@@ -332,11 +332,11 @@ static int child_fn(void* v) {
       return rc;
     }
   }
+#endif
 
   epilogue(ed);
   return 0;
 }
-#endif
 #endif
 
 int main(int argc, char* argv[], char* envp[]) {

--- a/userchroot.c
+++ b/userchroot.c
@@ -2,14 +2,12 @@
 #include <linux/version.h>
 #endif
 
-#if defined (__linux__) && defined (MOUNT_PROC)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+#if defined (__linux__)
 #define _GNU_SOURCE
 #define USERCHROOT_USE_LINUX_CLONE
 #include <sched.h>
 #include <sys/mount.h>
 #include <sys/wait.h>
-#endif
 #endif
 
 #include <unistd.h>


### PR DESCRIPTION
This improves the Linux-specific code to avoid mounts in the chroot (/proc and /dev/shm) affecting processes running outside of the chroot. The individual changes are described in the corresponding commit messages.

I've tested this only on Linux so far, however, the non-Linux code has also not been changed in a significant way.