### PR TITLE
Supplement owner check with access check for --install-devices

### DIFF
--- a/userchroot.c
+++ b/userchroot.c
@@ -591,9 +591,12 @@ int main(int argc, char* argv[], char* envp[]) {
       exit(ERR_EXIT_CODE);
     }
 
-    // this mode can only be run by the owner of the chroot image.
-    if (target_user != statbase_path.st_uid) {
-      fprintf(stderr,"install or uninstall devices can only be called by the owner of the chroot. Aborting.\n");
+    // this mode can only be run by the owner of the chroot image or
+    // users with write access to the /dev directory in the chroot image.
+    if (target_user != statbase_path.st_uid &&
+        access(dev_path, R_OK | W_OK | X_OK) != 0) {
+      fprintf(stderr,"install or uninstall devices can only be called by the owner of the chroot "
+        "or users with write access to /dev in the chroot. Error: %s\n", strerror(errno));
       exit(ERR_EXIT_CODE);
     }
 


### PR DESCRIPTION
The README claims that any user will be able to run commands as well as `--install-devices` and `--uninstall-devices`. However, that's not actually the case. The latter two are restricted to the owner of the chroot.

It makes sense to guard the creation of directory entries in chroot `/dev` directories. However, having read and write access to the `/dev` directory should suffice. This allows the chroot owner to control which other users can install devices, if any.

I'd suggest merging this after #14 as that untangles the `/dev/shm` mount from device node creation on Linux.